### PR TITLE
fix: use standard option names for HSTS and CSP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Header | Purpose | Default Policy
 [X-XSS-Protection](http://msdn.microsoft.com/en-us/library/dd565647(v=vs.85).aspx) | IE 8+ XSS protection header | *1; mode=block*
 [X-Content-Type-Options](http://msdn.microsoft.com/en-us/library/ie/gg622941(v=vs.85).aspx) | IE 9+ MIME-type verification | *nosniff*
 [X-Download-Options](http://msdn.microsoft.com/en-us/library/ie/jj542450(v=vs.85).aspx) | IE 10+ Prevent downloads from opening | *noopen*
-[Public-Key-Pins (HPKP)]() | Associate host with expected CA or public key | *max_age=5184000; includeSubdomains; report_uri=/hpkp_report [... no default pins]*
+[Public-Key-Pins (HPKP)]() | Associate host with expected CA or public key | *max_age=5184000; include_subdomains; report-uri=/hpkp_report [... no default pins]*
 
 
 ## Usage
@@ -28,8 +28,8 @@ Each header policy is represented by a dict of paramaters. [View default policie
 * Policies with just a string value are represented as {'value':parameter}
   * Ex: *{'value':'noopen'}* becomes *'noopen'*
 * Policies with additional string values are represented as {value:Bool}
-  * Ex: *{'maxage':1,'include_subdomains':True,'preload':False}* becomes *'maxage=1 include_subdomains'*
-* CSP is represented as a list inside the dict {cspPolicy:[param,param]}. 
+  * Ex: *{'max-age':1,'includeSubDomains':True,'preload':False}* becomes *'max-age=1 includeSubDomains'*
+* CSP is represented as a list inside the dict {cspPolicy:[param,param]}.
   * Ex: *{'script-src':['self']}* becomes *"script-src 'self'"*
   * self, none, nonce-* ,sha*, unsafe-inline, etc are automatically encapsulated
 * HPKP pins are represented by a list of dicts under the 'pins' paramter {'pins':[{hashType:hash}]}
@@ -53,14 +53,14 @@ There are two methods to change the default policies that will persist throughou
 To update/rewrite, pass a dict in of the desired values into the desired method:
 ```python
 """ update """
-sh.update({'CSP':{'script-src':['self','code.jquery.com']}}) 
+sh.update({'CSP':{'script-src':['self','code.jquery.com']}})
 # Content-Security-Policy: script-src 'self' code.jquery.com; report-uri /csp_report; default-src 'self
 sh.update(
  {'X_Permitted_Cross_Domain_Policies':{'value':'all'}},
  {'HPKP':{'pins':[{'sha256':'1234'}]}}
 )
 # X-Permitted-Cross-Domain-Policies: all
-# Public-Key-Pins: max_age=5184000; include_subdomains; report_uri=/hpkp_report; pin-sha256=1234
+# Public-Key-Pins: max-age=5184000; includeSubDomains; report-uri=/hpkp_report; pin-sha256=1234
 
 """ rewrite """
 sh.rewrite({'CSP':{'default-src':['none']}})
@@ -80,19 +80,19 @@ For non-CSP headers that contain multiple paramaters (HSTS and X-XSS-Protection)
 sh.update({'X-XSS-Protection':{'value':1,'mode':False}})
 # will produce X-XSS-Protection: 1
 
-sh.update({'HSTS':{'maxage':1,'include_subdomains':True,'preload':False}})
-# will produce Strict-Transport-Security: maxage=1; include_subdomains
+sh.update({'HSTS':{'max-age':1,'includeSubDomains':True,'preload':False}})
+# will produce Strict-Transport-Security: max-age=1; includeSubDomains
 ```
 
 ##### Read Only
 The HPKP and CSP Headers can be set to "-Read-Only" by passing "'read-only':True" into the policy dict. Examples:
 ```python
-sh.update({'CSP':{'script-src':['self','code.jquery.com']},'read-only':True}) 
+sh.update({'CSP':{'script-src':['self','code.jquery.com']},'read-only':True})
 sh.update({'HPKP':{'pins':[{'sha256':'1234'}]},'read-only':True})
 ```
 
 ##### Notes
-* Header keys can be written using either '_' or '-', but are case sensitive 
+* Header keys can be written using either '_' or '-', but are case sensitive
   * Acceptable: 'X-XSS-Protection','X_XSS_Protection'
   * Unacceptable: 'x-xss-protection'
 * 3 headers are abreviated

--- a/flask_secure_headers/core.py
+++ b/flask_secure_headers/core.py
@@ -29,14 +29,14 @@ class Secure_Headers:
 				'report-uri':['/csp_report'],
 			},
 			'HSTS':{
-				'max_age':31536000,
-				'includeSubdomains':True,
+				'max-age':31536000,
+				'includeSubDomains':True,
 				'preload':False
 			},
 			'HPKP':{
-				'max_age':5184000,
-				'includeSubdomains':True,
-				'report_uri':'/hpkp_report',
+				'max-age':5184000,
+				'includeSubDomains':True,
+				'report-uri':'/hpkp_report',
 				'pins':[],
 			},
 			'X_Frame_Options':{

--- a/flask_secure_headers/headers.py
+++ b/flask_secure_headers/headers.py
@@ -22,7 +22,7 @@ class Simple_Header:
 				raise ValueError("Invalid input for '%s' parameter. Options are: %s" % (k,' '.join(["'%s'," % str(o) for o in self.valid_opts[k]]) ))
 			else:
 				raise ValueError("Invalid parameter for '%s'. Params are: %s" % (self.__class__.__name__,', '.join(["'%s'" % p for p in self.valid_opts.keys()]) ))
-	
+
 	def update_policy(self,defaultHeaders):
 		""" if policy in default but not input still return """
 		if self.inputs is not None:
@@ -36,7 +36,7 @@ class Simple_Header:
 	def rewrite_policy(self,defaultHeaders):
 		""" return submitted policy """
 		return self.inputs
-	
+
 	def create_header(self):
 		""" return header dict """
 		try:
@@ -68,7 +68,7 @@ class X_Content_Type_Options(Simple_Header):
 	def __init__(self,inputs,overide=None):
 		self.valid_opts = {'value':['nosniff']}
 		self.inputs = inputs
-		
+
 
 class X_Download_Options(Simple_Header):
 	""" X_Download_Options """
@@ -91,21 +91,20 @@ class X_XSS_Protection(Simple_Header):
 class HSTS(Simple_Header):
 	""" HSTS """
 	def __init__(self,inputs,overide=None):
-		self.valid_opts = {'maxage':['[0-9]+'],'includeSubdomains':[True,False],'preload':[True,False]}
+		self.valid_opts = {'max-age':['[0-9]+'],'includeSubDomains':[True,False],'preload':[True,False]}
 		self.inputs = inputs
 		self.__class__.__name__ = 'Strict-Transport-Security'
 
 class HPKP(Simple_Header):
 	""" HPKP """
 	def __init__(self,inputs,overide=None):
-		self.valid_opts = {'maxage':['[0-9]+'],'includeSubdomains':[True,False],'report_uri':['*'],'pins':[[]]}
+		self.valid_opts = {'max-age':['[0-9]+'],'includeSubDomains':[True,False],'report-uri':['*'],'pins':[[]]}
 		self.inputs = inputs
 		self.__class__.__name__ = 'Public-Key-Pins'
 		if self.inputs is not None and 'report-only' in self.inputs:
 			if self.inputs['report-only'] is True:
 				self.__class__.__name__ += '-Report-Only'
 			del self.inputs['report-only']
-	
 	def update_policy(self,defaultHeaders):
 		""" rewrite update policy so that additional pins are added and not overwritten """
 		if self.inputs is not None:
@@ -117,7 +116,7 @@ class HPKP(Simple_Header):
 			return self.inputs
 		else:
 			return self.inputs
-					
+
 	def create_header(self):
 		""" rewrite return header dict for HPKP """
 		try:
@@ -146,13 +145,13 @@ class CSP:
 			if self.inputs['report-only'] is True:
 				self.header += '-Report-Only'
 			del self.inputs['report-only']
-	
+
 	def check_valid(self,cspDefaultHeaders):
 		if self.inputs is not None:
 			for p,l in self.inputs.items():
-				if p not in cspDefaultHeaders.keys() and p is not 'rewrite':		
+				if p not in cspDefaultHeaders.keys() and p is not 'rewrite':
 					raise ValueError("Invalid parameter '%s'. Params are: %s" % (p,', '.join(["'%s'" % p for p in cspDefaultHeaders.keys()]) ))
-	
+
 	def update_policy(self,cspDefaultHeaders):
 		""" add items to existing csp policies """
 		try:
@@ -165,12 +164,12 @@ class CSP:
 				return self.inputs
 		except Exception, e:
 			raise
-				
+
 	def rewrite_policy(self,cspDefaultHeaders):
 		""" fresh csp policy """
 		try:
-			self.check_valid(cspDefaultHeaders)		
-			if self.inputs is not None:	
+			self.check_valid(cspDefaultHeaders)
+			if self.inputs is not None:
 				for p,l in cspDefaultHeaders.items():
 					if p in self.inputs:
 						cspDefaultHeaders[p] = self.inputs[p]
@@ -182,11 +181,11 @@ class CSP:
 		except Exception, e:
 			raise
 
-	def create_header(self):		
-		""" return CSP header dict """		
+	def create_header(self):
+		""" return CSP header dict """
 		encapsulate =  re.compile("|".join(['^self','^none','^unsafe-inline','^unsafe-eval','^sha[\d]+-[\w=-]+','^nonce-[\w=-]+']))
 		csp = {}
 		for p,array in self.inputs.items():
 			csp[p] = ' '.join(["'%s'" % l if encapsulate.match(l) else l for l in array])
-			
+
 		return {self.header:'; '.join(['%s %s' % (k, v) for k, v in csp.items() if v != ''])}

--- a/flask_secure_headers/tests/core_test.py
+++ b/flask_secure_headers/tests/core_test.py
@@ -23,8 +23,8 @@ class TestCSPHeaderCreation(unittest.TestCase):
 		self.assertEquals(h['Content-Security-Policy'],"default-src 'none'")
 		""" test CSP -report-only header creation """
 		h = CSP({'default-src':['none'],'report-only':True}).create_header()
-		self.assertEquals(h['Content-Security-Policy-Report-Only'],"default-src 'none'")		
-	
+		self.assertEquals(h['Content-Security-Policy-Report-Only'],"default-src 'none'")
+
 	def test_CSP_fail(self):
 		""" test invalid paramter for CSP update """
 		with self.assertRaises(Exception):
@@ -32,11 +32,11 @@ class TestCSPHeaderCreation(unittest.TestCase):
 
 class TestAppUseCase(unittest.TestCase):
 	""" test header creation in flask app """
-	
+
 	def setUp(self):
 		self.app = Flask(__name__)
 		self.sh = Secure_Headers()
-	
+
 	def test_defaults(self):
 		""" test header wrapper with default headers """
 		@self.app.route('/')
@@ -45,14 +45,14 @@ class TestAppUseCase(unittest.TestCase):
 		with self.app.test_client() as c:
 			result = c.get('/')
 			self.assertEquals(result.headers.get('X-XSS-Protection'),'1; mode=block')
-			self.assertEquals(result.headers.get('Strict-Transport-Security'),'includeSubdomains; max_age=31536000')
-			self.assertEquals(result.headers.get('Public-Key-Pins'),'includeSubdomains; max_age=5184000; report_uri=/hpkp_report')			
+			self.assertEquals(result.headers.get('Strict-Transport-Security'),'includeSubDomains; max-age=31536000')
+			self.assertEquals(result.headers.get('Public-Key-Pins'),'includeSubDomains; report-uri=/hpkp_report; max-age=5184000')
 			self.assertEquals(result.headers.get('X-Content-Type-Options'),'nosniff')
 			self.assertEquals(result.headers.get('X-Permitted-Cross-Domain-Policies'),'none')
 			self.assertEquals(result.headers.get('X-Download-Options'),'noopen')
-			self.assertEquals(result.headers.get('X-Frame-Options'),'sameorigin')			
+			self.assertEquals(result.headers.get('X-Frame-Options'),'sameorigin')
 			self.assertEquals(result.headers.get('Content-Security-Policy'),"report-uri /csp_report; default-src 'self'")
-	
+
 	def test_update_function(self):
 		""" test config update function """
 		self.sh.update(
@@ -69,7 +69,7 @@ class TestAppUseCase(unittest.TestCase):
 			result = c.get('/')
 			self.assertEquals(result.headers.get('X-Permitted-Cross-Domain-Policies'),'all')
 			self.assertEquals(result.headers.get('Content-Security-Policy'),"script-src 'self' code.jquery.com; report-uri /csp_report; default-src 'self'")
-			self.assertEquals(result.headers.get('Public-Key-Pins'),"pin-sha256=test123; pin-sha256=test2256; includeSubdomains; report_uri=/hpkp_report; max_age=5184000")
+			self.assertEquals(result.headers.get('Public-Key-Pins'),"pin-sha256=test123; pin-sha256=test2256; includeSubDomains; report-uri=/hpkp_report; max-age=5184000")
 
 	def test_rewrite_function(self):
 		""" test config rewrite function """
@@ -86,7 +86,7 @@ class TestAppUseCase(unittest.TestCase):
 			result = c.get('/')
 			self.assertEquals(result.headers.get('Content-Security-Policy'),"default-src 'none'")
 			self.assertEquals(result.headers.get('Public-Key-Pins'),"pin-sha256=test123")
-	
+
 	def test_wrapper_update_function(self):
 		""" test updating policies from wrapper """
 		self.sh.rewrite(
@@ -117,11 +117,11 @@ class TestAppUseCase(unittest.TestCase):
 		with self.app.test_client() as c:
 			result = c.get('/test')
 			self.assertEquals(result.headers.get('Content-Security-Policy'),"script-src 'self' code.jquery.com 'nonce-1234'; default-src 'none'")
-	
+
 	def test_passing_none_value_rewrite(self):
 		""" test removing header from update/rewrite """
 		self.sh.rewrite({'CSP':None,'X_XSS_Protection':None})
-		@self.app.route('/')	
+		@self.app.route('/')
 		@self.sh.wrapper()
 		def index(): return "hi"
 		with self.app.test_client() as c:
@@ -129,17 +129,17 @@ class TestAppUseCase(unittest.TestCase):
 			self.assertEquals(result.headers.get('X-Permitted-Cross-Domain-Policies'),'none')
 			self.assertEquals(result.headers.get('CSP'),None)
 			self.assertEquals(result.headers.get('X-XSS-Protection'),None)
-	
+
 	def test_passing_none_value_wrapper(self):
 		""" test removing policy from wrapper """
-		@self.app.route('/')	
+		@self.app.route('/')
 		@self.sh.wrapper({'CSP':None,'X-XSS-Protection':None})
 		def index(): return "hi"
 		with self.app.test_client() as c:
 			result = c.get('/')
 			self.assertEquals(result.headers.get('X-Permitted-Cross-Domain-Policies'),'none')
-			self.assertEquals(result.headers.get('CSP'),None)	
+			self.assertEquals(result.headers.get('CSP'),None)
 			self.assertEquals(result.headers.get('X-XSS-Protection'),None)
 
 if __name__ == '__main__':
-    unittest.main()		
+    unittest.main()

--- a/flask_secure_headers/tests/headers_test.py
+++ b/flask_secure_headers/tests/headers_test.py
@@ -17,8 +17,8 @@ class TestPolicyCreation(unittest.TestCase):
 			r = h.create_header()
 		h = X_Frame_Options({'value':'fail'})
 		with self.assertRaises(Exception):
-			r = h.create_header()		
-	
+			r = h.create_header()
+
 	def test_X_Content_Type_Options_pass(self):
 		""" test valid X_Content_Type_Options"""
 		h = X_Content_Type_Options({'value':'nosniff'})
@@ -29,12 +29,12 @@ class TestPolicyCreation(unittest.TestCase):
 		h = X_Content_Type_Options({'values':'nosniff'})
 		with self.assertRaises(Exception):
 			r = h.create_header()
-	def test_X_Content_Type_Options_fail_parameter(self):	
+	def test_X_Content_Type_Options_fail_parameter(self):
 		""" test invalid parameter for X_Content_Type_Options"""
 		h = X_Content_Type_Options({'value':'fail'})
 		with self.assertRaises(Exception):
-			r = h.create_header()	
-	
+			r = h.create_header()
+
 	def test_X_Download_Options_pass(self):
 		""" test valid X_Download_Options"""
 		h = X_Download_Options({'value':'noopen'})
@@ -49,7 +49,7 @@ class TestPolicyCreation(unittest.TestCase):
 		""" test invalid parameter for X_Download_Options"""
 		h = X_Download_Options({'value':'fail'})
 		with self.assertRaises(Exception):
-			r = h.create_header()	
+			r = h.create_header()
 
 	def test_X_Permitted_Cross_Domain_Policies_pass(self):
 		""" test valid X_Permitted_Cross_Domain_Policies"""
@@ -65,8 +65,8 @@ class TestPolicyCreation(unittest.TestCase):
 		""" test invalid parameter for X_Permitted_Cross_Domain_Policies"""
 		h = X_Permitted_Cross_Domain_Policies({'value':'fail'})
 		with self.assertRaises(Exception):
-			r = h.create_header()	
-					
+			r = h.create_header()
+
 	def test_X_XSS_Protection_pass_int(self):
 		""" test valid X_XSS_Protection (int)"""
 		h = X_XSS_Protection({'value':1})
@@ -76,7 +76,7 @@ class TestPolicyCreation(unittest.TestCase):
 		""" test valid X_XSS_Protection (str)"""
 		h = X_XSS_Protection({'value':'1'})
 		r = h.create_header()
-		self.assertEquals(r['X-XSS-Protection'],'1')		
+		self.assertEquals(r['X-XSS-Protection'],'1')
 	def test_X_XSS_Protection_pass_second_param(self):
 		""" test valid X_XSS_Protection (with second parameter)"""
 		h = X_XSS_Protection({'value':'1','mode':'block'})
@@ -86,7 +86,7 @@ class TestPolicyCreation(unittest.TestCase):
 		""" test valid X_XSS_Protection (with second parameter set to false)"""
 		h = X_XSS_Protection({'value':'1','mode':False})
 		r = h.create_header()
-		self.assertEquals(r['X-XSS-Protection'],'1')		
+		self.assertEquals(r['X-XSS-Protection'],'1')
 	def test_X_XSS_Protection_fail_input(self):
 		""" test invalid input for X_XSS_Protection"""
 		h = X_XSS_Protection({'values':1})
@@ -105,60 +105,56 @@ class TestPolicyCreation(unittest.TestCase):
 
 	def test_HSTS_pass_int(self):
 		""" test valid HSTS (int)"""
-		h = HSTS({'maxage':23})
+		h = HSTS({'max-age':23})
 		r = h.create_header()
-		self.assertEquals(r['Strict-Transport-Security'],'maxage=23')
+		self.assertEquals(r['Strict-Transport-Security'],'max-age=23')
 	def test_HSTS_pass_str(self):
 		""" test valid HSTS (str)"""
-		h = HSTS({'maxage':'23'})
+		h = HSTS({'max-age':'23'})
 		r = h.create_header()
-		self.assertEquals(r['Strict-Transport-Security'],'maxage=23')		
+		self.assertEquals(r['Strict-Transport-Security'],'max-age=23')
 	def test_HSTS_pass_second_param(self):
 		""" test valid HSTS (with second parameter)"""
-		h = HSTS({'maxage':23,'includeSubdomains':True,'preload':False})
+		h = HSTS({'max-age':23,'includeSubDomains':True,'preload':False})
 		r = h.create_header()
-		self.assertEquals(r['Strict-Transport-Security'],'includeSubdomains; maxage=23')		
+		self.assertEquals(r['Strict-Transport-Security'],'includeSubDomains; max-age=23')
 	def test_HSTS_fail_input(self):
 		""" test invalid input for HSTS """
 		h = HSTS({'values':23})
 		with self.assertRaises(Exception):
 			r = h.create_header()
 	def test_HSTS_fail_input_non_digit(self):
-		""" test non-digit maxage value for HSTS """
-		h = HSTS({'maxage':'fail'})
+		""" test non-digit max-age value for HSTS """
+		h = HSTS({'max-age':'fail'})
 		with self.assertRaises(Exception):
 			r = h.create_header()
 	def test_HSTS_fail_non_boolean(self):
-		""" test non-boolean includeSubdomains value for HSTS """
-		h = HSTS({'maxage':'23','includeSubdomains':'Test'})
+		""" test non-boolean includeSubDomains value for HSTS """
+		h = HSTS({'max-age':'23','includeSubDomains':'Test'})
 		with self.assertRaises(Exception):
-			r = h.create_header()		
-			
+			r = h.create_header()
+
 	def test_HPKP_pass(self):
 		""" test valid HPKP """
-		h = HPKP({'maxage':'23','includeSubdomains':True,'pins':[{'sha256':'1234'}]})
+		h = HPKP({'max-age':'23','includeSubDomains':True,'pins':[{'sha256':'1234'}]})
 		r = h.create_header()
-		self.assertEquals(r['Public-Key-Pins'],'includeSubdomains; pin-sha256=1234; maxage=23')
+		self.assertEquals(r['Public-Key-Pins'],'includeSubDomains; pin-sha256=1234; max-age=23')
 	def test_HPKP_pass_2_pins(self):
 		""" test valid HPKP """
-		h = HPKP({'maxage':'23','includeSubdomains':True,'pins':[{'sha256':'1234'},{'sha256':'abcd'}]})
+		h = HPKP({'max-age':'23','includeSubDomains':True,'pins':[{'sha256':'1234'},{'sha256':'abcd'}]})
 		r = h.create_header()
-		self.assertEquals(r['Public-Key-Pins'],'includeSubdomains; pin-sha256=1234; pin-sha256=abcd; maxage=23')
+		self.assertEquals(r['Public-Key-Pins'],'includeSubDomains; pin-sha256=1234; pin-sha256=abcd; max-age=23')
 	def test_HPKP_pass_no_pins(self):
 		""" test valid HPKP (with no pins) """
-		h = HPKP({'maxage':'23','includeSubdomains':True})
+		h = HPKP({'max-age':'23','includeSubDomains':True})
 		r = h.create_header()
-		self.assertEquals(r['Public-Key-Pins'],'includeSubdomains; maxage=23')		
-	def test_HPKP_pass_no_includeSubdomains(self):
+		self.assertEquals(r['Public-Key-Pins'],'includeSubDomains; max-age=23')
+	def test_HPKP_pass_no_include_subdomains(self):
 		""" test valid HPKP (with no pins) """
-		h = HPKP({'maxage':'23','includeSubdomains':False})
+		h = HPKP({'max-age':'23','includeSubDomains':False})
 		r = h.create_header()
-	def test_HPKP_pass_report_only(self):
-		""" test valid HPKP for Report-Only header """
-		h = HPKP({'maxage':'23','includeSubdomains':True,'pins':[{'sha256':'1234'}],'report-only':True})
-		r = h.create_header()		
-		self.assertEquals(r['Public-Key-Pins-Report-Only'],'includeSubdomains; pin-sha256=1234; maxage=23')		
-	def test_HPKP_fail_nonList(self):
+		self.assertEquals(r['Public-Key-Pins'],'max-age=23')
+	def test_HPHP_fail_nonList(self):
 		""" test invalid pins argument for HPKP (not passing list for pins argument) """
 		h = HPKP({'pins':'test'})
 		with self.assertRaises(Exception):
@@ -169,17 +165,17 @@ class TestPolicyCreation(unittest.TestCase):
 		with self.assertRaises(Exception):
 			r = h.create_header()
 	def test_HPKP_fail_parameter(self):
-		""" test non-digit maxage value for HPKP """
-		h = HPKP({'maxage':'test'})
+		""" test non-digit max-age value for HPKP """
+		h = HPKP({'max-age':'test'})
 		with self.assertRaises(Exception):
 			r = h.create_header()
 	def test_HPKP_fail_non_boolean(self):
-		""" test non-boolean includeSubdomains value for HSTS """
-		h = HPKP({'maxage':'23','includeSubdomains':'Test'})
+		""" test non-boolean include_subdomains value for HSTS """
+		h = HPKP({'max-age':'23','includeSubDomains':'Test'})
 		with self.assertRaises(Exception):
-			r = h.create_header()					
-			
-			
-					
+			r = h.create_header()
+
+
+
 if __name__ == '__main__':
-    unittest.main()		
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
   name = 'flask-secure-headers',
   packages = ['flask_secure_headers'],
   include_package_data = True,
-  version = '0.4',
+  version = '0.5',
   description = 'Secure Header Wrapper for Flask Applications',
   long_description = ('Add security headers to a Flask application. '
                       'This is intended to be a simplified version of the '


### PR DESCRIPTION
This will remove errors in my Firefox.
